### PR TITLE
Use const qualifier for device prop in prepmodel5, cyclesPacked, and cyclesTiled

### DIFF
--- a/src/cuttGpuModel.cpp
+++ b/src/cuttGpuModel.cpp
@@ -795,7 +795,7 @@ struct GpuModelProp {
   }
 };
 
-void prepmodel5(hipDeviceProp_t& prop, GpuModelProp& gpuModelProp,
+void prepmodel5(const hipDeviceProp_t& prop, GpuModelProp& gpuModelProp,
   int nthread, int numActiveBlock, float mlp,
   int gld_req, int gst_req, int gld_tran, int gst_tran,
   int sld_req, int sst_req, int sld_tran, int sst_tran,
@@ -841,7 +841,7 @@ void prepmodel5(hipDeviceProp_t& prop, GpuModelProp& gpuModelProp,
   MWP = std::min(MWP*mlp, std::min(MWP_peak_BW, (double)active_warps_per_SM));
 }
 
-double cyclesPacked(const bool isSplit, const size_t sizeofType, hipDeviceProp_t& prop,
+double cyclesPacked(const bool isSplit, const size_t sizeofType, const hipDeviceProp_t& prop,
   int nthread, int numActiveBlock, float mlp, 
   int gld_req, int gst_req, int gld_tran, int gst_tran,
   int sld_req, int sst_req, int sld_tran, int sst_tran, int num_iter, int cl_full, int cl_part) {
@@ -863,7 +863,7 @@ double cyclesPacked(const bool isSplit, const size_t sizeofType, hipDeviceProp_t
   return cycles;
 }
 
-double cyclesTiled(const bool isCopy, const size_t sizeofType, hipDeviceProp_t& prop,
+double cyclesTiled(const bool isCopy, const size_t sizeofType, const hipDeviceProp_t& prop,
   int nthread, int numActiveBlock, float mlp, 
   int gld_req, int gst_req, int gld_tran, int gst_tran,
   int sld_req, int sst_req, int sld_tran, int sst_tran, int num_iter, int cl_full, int cl_part) {

--- a/src/cuttGpuModel.h
+++ b/src/cuttGpuModel.h
@@ -73,12 +73,12 @@ void countTiledGlTransactions(const bool leadVolSame,
   std::vector<TensorConvInOut>& hostMbar, const int sizeMbar,
   int& num_iter, float& mlp, int& gld_tran, int& gst_tran, int& gld_req, int& gst_req, int& cl_full, int& cl_part);
 
-double cyclesPacked(const bool isSplit, const size_t sizeofType, hipDeviceProp_t& prop,
+double cyclesPacked(const bool isSplit, const size_t sizeofType, const hipDeviceProp_t& prop,
   int nthread, int numActiveBlock, float mlp, 
   int gld_req, int gst_req, int gld_tran, int gst_tran,
   int sld_req, int sst_req, int sld_tran, int sst_tran, int num_iter, int cl_full, int cl_part);
 
-double cyclesTiled(const bool isCopy, const size_t sizeofType, hipDeviceProp_t& prop,
+double cyclesTiled(const bool isCopy, const size_t sizeofType, const hipDeviceProp_t& prop,
   int nthread, int numActiveBlock, float mlp, 
   int gld_req, int gst_req, int gld_tran, int gst_tran,
   int sld_req, int sst_req, int sld_tran, int sst_tran, int num_iter, int cl_full, int cl_part);

--- a/src/cutt_test.cpp
+++ b/src/cutt_test.cpp
@@ -53,7 +53,7 @@ cuttTimer* timerDouble;
 
 long long int* dataIn  = NULL;
 long long int* dataOut = NULL;
-int dataSize  = 20000000;
+int dataSize  = 200000000;
 TensorTester* tester = NULL;
 
 bool test1();
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
   if(passed){passed = test1(); if(!passed) printf("Test 1 failed\n");}
   if(passed){passed = test2(); if(!passed) printf("Test 2 failed\n");}
   if(passed){passed = test3(); if(!passed) printf("Test 3 failed\n");}
-  //if(passed){passed = test4(); if(!passed) printf("Test 4 failed\n");}
+  if(passed){passed = test4(); if(!passed) printf("Test 4 failed\n");}
   //if(passed){passed = test5(); if(!passed) printf("Test 5 failed\n");}
 
   if(passed){
@@ -267,9 +267,9 @@ bool test3() {
     int rank = 3;
     std::vector<int> dim(rank);
     std::vector<int> permutation(rank);
-    dim[0] = 651;
-    dim[1] = 299;
-    dim[2] = 44;
+    dim[0] = 1305;
+    dim[1] = 599;
+    dim[2] = 88;
     permutation[0] = 0;
     permutation[1] = 2;
     permutation[2] = 1;
@@ -282,9 +282,9 @@ bool test3() {
     std::vector<int> dim(rank);
     std::vector<int> permutation(rank);
     dim[0] = 24;
-    dim[1] = 170;
-    dim[2] = 32;
-    dim[3] = 97;
+    dim[1] = 330;
+    dim[2] = 64;
+    dim[3] = 147;
     permutation[0] = 1;
     permutation[1] = 0;
     permutation[2] = 2;
@@ -333,10 +333,10 @@ bool test3() {
     std::vector<int> dim(5);
     std::vector<int> permutation(5);
     dim[0] = 5;
-    dim[1] = 32;
-    dim[2] = 45;
-    dim[3] = 63;
-    dim[4] = 37;
+    dim[1] = 42;
+    dim[2] = 75;
+    dim[3] = 86;
+    dim[4] = 57;
     permutation[0] = 2 - 1;
     permutation[1] = 4 - 1;
     permutation[2] = 5 - 1;


### PR DESCRIPTION
These functions do not modify device property and could use const qualifier for prop. Tested TT on all three GPU platforms.